### PR TITLE
Upgrade to PHP 7.1

### DIFF
--- a/alias.php
+++ b/alias.php
@@ -104,7 +104,7 @@ class Alias {
 					$insert->execute();
 					
 					Go::log("Created alias via Alias::__construct().", $code, $institution, $name);
-				} catch(Exception $e) {
+				} catch(Throwable $e) {
 					throw $e;
 				}
 			} else {
@@ -113,7 +113,7 @@ class Alias {
 				$this->setInstitution($row->institution);
 				$this->setCode($row->code);
 			}
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			throw $e;
 		}
 	}
@@ -211,7 +211,7 @@ class Alias {
 				
 				Go::log("Updated alias name from '".$this->name."' to '$name' via Alias::setName(). 1 of 2.", $this->code, $this->institution, $this->name);
 				Go::log("Updated alias name from '".$this->name."' to '$name' via Alias::setName(). 2 of 2.", $this->code, $this->institution, $name);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -247,7 +247,7 @@ class Alias {
 			if ($select->rowCount() == 0) {
 				throw new Exception("There is no code " . $code);
 			}
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			throw $e;
 		}
 			
@@ -265,7 +265,7 @@ class Alias {
 				
 				Go::log("Updated alias code from '".$this->code."' to '$code' via Alias::setCode(). 1 of 2.", $this->code, $this->institution, $this->name);
 				Go::log("Updated alias code from '".$this->code."' to '$code' via Alias::setCode(). 2 of 2.", $code, $this->institution, $this->name);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -306,7 +306,7 @@ class Alias {
 				
 				Go::log("Updated alias institution from '".$this->institution."' to '$institution' via Alias::setInstitution(). 1 of 2.", $this->code, $this->institution, $this->name);
 				Go::log("Updated alias institution from '".$this->institution."' to '$institution' via Alias::setInstitution(). 2 of 2.", $this->code, $institution, $this->name);
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				throw $e;
 			}
 		}
@@ -331,7 +331,7 @@ class Alias {
 			$alias->execute();
 			
 			Go::log("Deleted alias via Alias::delete().", $this->code, $this->institution, $this->name);
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			throw $e;
 		}
 	}

--- a/code.php
+++ b/code.php
@@ -293,7 +293,7 @@ class Code {
 					$insert->execute();
 					
 					Go::log("Created code $name via Code::__construct().", $name, $institution);
-				} catch(Exception $e) {
+				} catch(Throwable $e) {
 					throw $e;
 				}
 			} else {
@@ -306,7 +306,7 @@ class Code {
 				$this->setUnsearchable(($row->unsearchable == "1"));
 				$this->setUpdated($row->updated);
 			}
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			throw $e;
 		}
 	}
@@ -407,7 +407,7 @@ class Code {
 			} else {
 				throw new Exception("The user {$user} does not have access to code {$this->name}");
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 	}
@@ -435,7 +435,7 @@ class Code {
 			}
 			
 			$select->closeCursor();
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		
@@ -510,7 +510,7 @@ class Code {
 				
 				Go::log("Updated code name from '".$this->name."' to '$name' via Code::setName(). 1 of 2.", $this->name, $this->institution);
 				Go::log("Updated code name from '".$this->name."' to '$name' via Code::setName(). 2 of 2.", $name, $this->institution);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -550,7 +550,7 @@ class Code {
 				if ($select->rowCount() > 0) {
 					throw new Exception("The code " . $this->name . " already exists.");
 				}
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				throw $e;
 			}
 		}
@@ -567,7 +567,7 @@ class Code {
 				
 				Go::log("Updated code institution from '".$this->institution."' to '$institution' via Code::setInstitution(). 1 of 2.", $this->name, $this->institution);
 				Go::log("Updated code institution from '".$this->institution."' to '$institution' via Code::setName(). 2 of 2.", $this->name, $institution);
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				throw $e;
 			}
 		}
@@ -606,7 +606,7 @@ class Code {
 				$update->execute();
 				
 				Go::log("Updated code url to '$url' via Code::setUrl().", $this->name, $this->institution);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -691,7 +691,7 @@ class Code {
 				
 				Go::log("Updated code description to '$description' via Code::setDescription().", $this->name, $this->institution);
 
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -730,7 +730,7 @@ class Code {
 				$update->execute();
 				
 				Go::log("Updated code publicity to '".($public ? "1" : "0")."' via Code::setPublic().", $this->name, $this->institution);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -769,7 +769,7 @@ class Code {
 				$update->execute();
 				
 				Go::log("Updated code unsearchablity to '".($unsearchable ? "1" : "0")."' via Code::setUnsearchable().", $this->name, $this->institution);
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -831,7 +831,7 @@ class Code {
 			$code->execute();
 			
 			Go::log("Deleted code via Code::delete().", $this->name, $this->institution);
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			throw $e;
 		}
 	}
@@ -856,7 +856,7 @@ class Code {
 			if (isset($code)) {
 				throw new Exception("User {$name} already has access to {$this->name}");
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 			
@@ -868,7 +868,7 @@ class Code {
 			$insert->execute();
 			
 			Go::log("Added user '".$name."' to code via Code::addUser().", $this->name, $this->institution);
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 	}
@@ -897,7 +897,7 @@ class Code {
 			if (!isset($code)) {
 				throw new Exception("User {$name} does not have access to {$this->name}");
 			} 
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 			
@@ -910,7 +910,7 @@ class Code {
 			
 			Go::log("Removed user '".$name."' from code via Code::addUser().", $this->name, $this->institution);
 
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 	}
@@ -938,7 +938,7 @@ class Code {
 			}
 			
 			$select->closeCursor();
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		
@@ -1013,7 +1013,7 @@ ORDER BY tstamp ASC
 					$users[] = new User($m[2]);
 				}
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		
@@ -1285,7 +1285,7 @@ ORDER BY alias
 			foreach ($select->fetchAll(PDO::FETCH_OBJ) as $row) {
 				$aliases[$row->name] = new DeletedAlias($row->alias, $this->name, $this->institution);
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		

--- a/details.php
+++ b/details.php
@@ -100,8 +100,8 @@ try {
   <?php
 
 //now catch any exceptions
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	throw $e;
-} //end catch (Exception $e) {
+} //end catch (Throwable $e) {
 
 require_once "footer.php";

--- a/flag.php
+++ b/flag.php
@@ -128,7 +128,7 @@ try {
   $message->send($to, $headers, $body);
   //}
 //now catch any exceptions
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	throw $e;
 }
 

--- a/flag_admin.php
+++ b/flag_admin.php
@@ -199,7 +199,7 @@ try {
   </table>
   
   <?php //now catch any exceptions
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	throw $e;
 }
 

--- a/flag_clear.php
+++ b/flag_clear.php
@@ -67,9 +67,9 @@ try {
   $message->send($to, $headers, $body);
 	
 //now catch any exceptions
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	throw $e;
-} //end catch (Exception $e) {
+} //end catch (Throwable $e) {
 
 //redirect on completion
 header("location: flag_admin.php?code=".$_POST['code']);

--- a/header.php
+++ b/header.php
@@ -8,7 +8,7 @@ $name = "";
 if (isset($_SESSION["AUTH"])) {
   try {
     $name = $_SESSION["AUTH"]->getName();
-  } catch (Exception $e) {
+  } catch (Throwable $e) {
     // We may have an expired proxy-ticket kept around. If so, regenerate the session
     // and log-in again.
     if ($e->getCode() == PHPCAS_SERVICE_PT_FAILURE) {

--- a/header_midd.php
+++ b/header_midd.php
@@ -8,7 +8,7 @@ $name = "";
 if (isset($_SESSION["AUTH"])) {
   try {
     $name = $_SESSION["AUTH"]->getName();
-  } catch (Exception $e) {
+  } catch (Throwable $e) {
     // We may have an expired proxy-ticket kept around. If so, regenerate the session
     // and log-in again.
     if ($e->getCode() == PHPCAS_SERVICE_PT_FAILURE) {

--- a/header_miis.php
+++ b/header_miis.php
@@ -8,7 +8,7 @@ $name = "";
 if (isset($_SESSION["AUTH"])) {
   try {
     $name = $_SESSION["AUTH"]->getName();
-  } catch (Exception $e) {
+  } catch (Throwable $e) {
     // We may have an expired proxy-ticket kept around. If so, regenerate the session
     // and log-in again.
     if ($e->getCode() == PHPCAS_SERVICE_PT_FAILURE) {

--- a/info.php
+++ b/info.php
@@ -164,7 +164,7 @@ try {
 				</form>
 
 				<?php 
-				} catch (Exception $e) {
+				} catch (Throwable $e) {
 					error_log($e->getMessage(), 3);
 					print "<div class='error'>Error. Please contact ".GO_HELP_HTML."</div>";
 				} ?>

--- a/login.php
+++ b/login.php
@@ -6,7 +6,7 @@ if (isset($_POST["username"]) && isset($_POST["password"])) {
   try {
     $_SESSION["AUTH"] = new GoAuthLdap($_POST["username"], $_POST["password"]);
     header("Location: " . $_POST["r"]);
-  } catch(Exception $e) {
+  } catch(Throwable $e) {
 		error_log($e->getMessage(), 3);
     $error = TRUE;
   }

--- a/phpqrcode.php
+++ b/phpqrcode.php
@@ -1098,7 +1098,7 @@
                 $this->bstream = $bs;
                 return 0;
                 
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1128,7 +1128,7 @@
                 $this->bstream = $bs;
                 return 0;
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1149,7 +1149,7 @@
                 $this->bstream = $bs;
                 return 0;
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1181,7 +1181,7 @@
                 $this->bstream = $bs;
                 return 0;
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1200,7 +1200,7 @@
                 $this->bstream = $bs;
                 return 0;
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1276,7 +1276,7 @@
 
                 return $this->bstream->size();
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1354,7 +1354,7 @@
                 $entry = new QRinputItem($mode, $size, $data);
                 $this->items[] = $entry;
                 return 0;
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -1377,7 +1377,7 @@
                 $entry = new QRinputItem(QR_MODE_STRUCTURE, 3, buf);
                 array_unshift($this->items, $entry);
                 return 0;
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
                 return -1;
             }
         }
@@ -3301,7 +3301,7 @@
                 
                 QRimage::png($tab, $outfile, min(max(1, $this->size), $maxSize), $this->margin,$saveandprint);
             
-            } catch (Exception $e) {
+            } catch (Throwable $e) {
             
                 QRtools::log($outfile, $e->getMessage());
             

--- a/process.php
+++ b/process.php
@@ -5,10 +5,6 @@ require_once "go_functions.php";
 //pages and pages where a session is necessary
 require_once "go.php";
 
-// Debugging code
-//var_dump($_POST);
-//die();
-
 // Add the results of $_POST to $_SESSION. We'll use
 // this to repopulate values in the form if it fails
 // validation
@@ -125,9 +121,9 @@ if (isset($_SESSION['AUTH'])) {
 			$code = new Code($_POST['code'], $_POST['institution']);
 			if (!empty($showCreateMessage))
 				$_SESSION['update_message'][] = "<p class='update_message_success'>The shortcut ".$_POST['code']." was created.</p>";
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			error_log($e->getMessage(), 3);
-			$_SESSION['update_message'][] = "<p class='update_message_failure'>Adding code failed. Please try again and contact ".GO_HELP_HTML." if you encounter an error.</p>";
+			$_SESSION['update_message'][] = "<p class='update_message_failure'>Adding code failed." . $e->getMessage() . " Please try again and contact ".GO_HELP_HTML." if you encounter an error.</p>";
 			header("location: " . $_POST['form_url']);
 			exit;
 		}
@@ -210,7 +206,7 @@ if (isset($_SESSION['AUTH'])) {
 							// Otherwise make a new alias and set a message
 							$alias = new Alias($current_alias, $_POST['code'], $_POST['institution']);
 							$_SESSION['update_message'][] = "<p class='update_message_success'>Alias ".$current_alias." was added to '".$code->getName()."'.</p>";
-						} catch (Exception $e) {
+						} catch (Throwable $e) {
 							error_log($e->getMessage(), 3);
 							$_SESSION['update_message'][] = "<p class='update_message_failure'>Adding alias ".$current_alias." failed. Please try again and contact  ".GO_HELP_HTML."  if you encounter an error.</p>";
 						}
@@ -298,7 +294,7 @@ if (isset($_SESSION['AUTH'])) {
 								try {
 									$code->delUser($_SESSION["AUTH"]->getId($current_admin));
 								//if the user isn't found and the ID is passed, just use the id
-								} catch (Exception $e) {
+								} catch (Throwable $e) {
 									$code->delUser($current_admin);
 								}
 								$_SESSION['update_message'][] = "<p class='update_message_success'>User ".$current_admin." was removed as an admin of '".$code->getName()."'.</p>";
@@ -310,7 +306,7 @@ if (isset($_SESSION['AUTH'])) {
 						try { 
 							$code->delUser($_SESSION["AUTH"]->getId($current_admin));
 						//if the user isn't found and the ID is passed, just use the id
-						} catch (Exception $e) {
+						} catch (Throwable $e) {
 							$code->delUser($current_admin);
 						}
 						$_SESSION['update_message'][] = "<p class='update_message_success'>User ".$current_admin." was removed as an admin of '".$code->getName()."'.</p>";

--- a/qr.php
+++ b/qr.php
@@ -10,7 +10,7 @@ try {
 	
 	QRcode::png('http://go.'.$institution.'/' . $code->getName());
 
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	error_log($e->getMessage(), 3);
 	print "<div class='error'>Error. Please contact ".GO_HELP_HTML."</div>";
 }

--- a/redirect.php
+++ b/redirect.php
@@ -28,7 +28,7 @@ try {
 
 	try {
 		$code = Code::get($name, $institution);
-	} catch (Exception $e) {
+	} catch (Throwable $e) {
 		// If not found, send to the gotionary.
 		header("Location: ".$basePath."gotionary.php?letter=" . substr($name, 0, 1));
 		exit;
@@ -68,7 +68,7 @@ try {
 		exit;
 	}
 
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	header("Location: ".$basePath."info.php?code=" . $name);
 	exit;
 }

--- a/update.php
+++ b/update.php
@@ -100,7 +100,7 @@ if (isset($_SESSION['AUTH'])) {
 								try {
 									$username = $_SESSION["AUTH"]->getName($cUser->getName());
 								//if there is an exception, use the id as the username
-								} catch (Exception $e) {
+								} catch (Throwable $e) {
 									$username = $cUser->getName();
 								}
 								print "<li id='" . $username . "'>". $username;

--- a/user.php
+++ b/user.php
@@ -78,14 +78,14 @@ class User {
 					$insert = $connection->prepare("INSERT INTO user (name, notify) VALUES (:name, 1)");
 					$insert->bindValue(":name", $name);
 					$insert->execute();
-				} catch (Exception $e) {
+				} catch (Throwable $e) {
 					throw $e;
 				}
 			} else {
 				$row = $select->fetch(PDO::FETCH_LAZY, PDO::FETCH_ORI_NEXT);
 				$this->setNotify(($row->notify == "1"));
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 	}
@@ -149,7 +149,7 @@ class User {
 				$this->codes[$institution . "/" . $code] = new Code($code, $institution);
 				return $this->codes[$institution . "/" . $code];
 			}
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 	}
@@ -176,7 +176,7 @@ class User {
 			}
 			
 			$select->closeCursor();
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		
@@ -213,7 +213,7 @@ ORDER BY log.code ASC, log.tstamp DESC");
 			}
 			
 			$select->closeCursor();
-		} catch(Exception $e) {
+		} catch(Throwable $e) {
 			throw $e;
 		}
 		
@@ -243,7 +243,7 @@ ORDER BY log.code ASC, log.tstamp DESC");
 				$update->bindValue(":name", $name);
 				$update->bindValue(":oldname", $this->name);
 				$update->execute();
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}
@@ -279,7 +279,7 @@ ORDER BY log.code ASC, log.tstamp DESC");
 				$update->bindValue(":notify", ($notify ? "1" : "0"));
 				$update->bindValue(":name", $this->name);
 				$update->execute();
-			} catch(Exception $e) {
+			} catch(Throwable $e) {
 				throw $e;
 			}
 		}

--- a/user_codes.php
+++ b/user_codes.php
@@ -51,7 +51,7 @@ try {
 			print_codes_table($codes, false);
 		}
 	}
-} catch (Exception $e) {
+} catch (Throwable $e) {
 	error_log($e->getMessage(), 3);
 	print "<div class='error'>Error. Please contact ".GO_HELP_HTML."</div>"; 
 }


### PR DESCRIPTION
After reviewing the codebase in light of this article: http://php.net/manual/en/migration70.incompatible.php it seems that GO should be good to... go... for PHP 7.1

The application worked just fine without any changes to the code base.  I tested every function I could think to test and everything was honky dory.

I did make one major change based on a suggestion from this article: https://trowski.com/2015/06/24/throwable-exceptions-and-errors-in-php7/ which recommended that for any "catch all" catch blocks, we switch from `catch (Exception $e)` to `catch (Throwable $e)`.

This is because in PHP 7+, there is now an Exception class and an Error class, both of which inherit a new interface called Throwable.  While in 5.6 we could expect any "errors" to be of type Exception, we can no longer make that assumption in a general sense.  So, it is best practice when we are unsure whether we will receive an Exception or an Error to catch Throwables instead.  When we are expecting specific errors, we can leave such catch blocks alone.

All that being said, I'm not sure why we catch errors only to throw them, which we do several times in this codebase.  E.g.:
```
// I don't understand why we do this.
catch (Throwable $e) {
    throw $e;
}
```